### PR TITLE
[Fixed]Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにし、

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -27,17 +27,33 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
-      I18n.t('views.messages.cannot_delete_the_leader')
-    elsif Assign.where(user_id: assigned_user.id).count == 1
-      I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
-      set_next_team(assign, assigned_user)
-      I18n.t('views.messages.delete_member')
-    else
-      I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      if assigned_user == assign.team.owner
+        I18n.t('views.messages.cannot_delete_the_leader')
+      elsif Assign.where(user_id: assigned_user.id).count == 1
+        I18n.t('views.messages.cannot_delete_only_a_member')
+      elsif current_user.id != assigned_user.id
+        if current_user.id == assign.team.owner.id
+          assign.destroy
+          set_next_team(assign, assigned_user)
+          I18n.t('views.messages.delete_member')
+        else
+          I18n.t('views.messages.cannot_delete_another_member')
+        end
+      elsif current_user.id != assign.team.owner.id
+        if current_user.id == assigned_user.id
+          assign.destroy
+          set_next_team(assign, assigned_user)
+          I18n.t('views.messages.delete_member')
+        else
+          I18n.t('views.messages.only_leader_can_delete_a_member')
+        end
+      elsif assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      end
     end
-  end
 
   def email_exist?
     team = find_team(params[:team_id])

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :team_edit, only: %i[edit]
 
   def index
     @teams = Team.all
@@ -15,7 +16,8 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+  end
 
   def create
     @team = Team.new(team_params)
@@ -55,5 +57,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def team_edit
+    unless current_user == @team.owner
+      redirect_to teams_url, notice: "編集はリーダーのみが行えます。"
+    end
   end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,7 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+             <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' if current_user.id == @team.owner.id %>
           </div>
 
           <div class="col-md-8">


### PR DESCRIPTION
TeamのeditはTeamのリーダー（オーナー）のみができるようにした